### PR TITLE
Bump `pug` version to fix vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kue",
-  "version": "0.12.0",
+  "version": "0.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kue",
-      "version": "0.12.0",
+      "version": "0.12.2",
       "license": "MIT",
       "dependencies": {
         "body-parser": "^1.12.2",
@@ -14,7 +14,7 @@
         "lodash": "^4.0.0",
         "nib": "~1.1.2",
         "node-redis-warlock": "^1.0.2",
-        "pug": "^3.0.2",
+        "pug": "^3.0.3",
         "redis": "^3.0.0",
         "stylus": "~0.54.5",
         "yargs": "^17.4.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kue",
-  "version": "0.12.0",
+  "version": "0.12.2",
   "description": "Feature rich priority job queue backed by redis",
   "homepage": "http://automattic.github.io/kue/",
   "keywords": [
@@ -30,7 +30,7 @@
     "lodash": "^4.0.0",
     "nib": "~1.1.2",
     "node-redis-warlock": "^1.0.2",
-    "pug": "^3.0.2",
+    "pug": "^3.0.3",
     "redis": "^3.0.0",
     "stylus": "~0.54.5",
     "yargs": "^17.4.1"


### PR DESCRIPTION
## Changes
- bumped `pug` package to `3.0.3` version to fix vulnerabilities 